### PR TITLE
Enable combined 'geocode|establishment' type

### DIFF
--- a/lib/services/Google.service.ts
+++ b/lib/services/Google.service.ts
@@ -5,7 +5,7 @@ const BASE_URL = 'https://maps.googleapis.com/maps/api/place';
 export interface Query {
   language: string;
   key: string;
-  types: 'address' | 'geocode' | 'cities' | 'establishment';
+  types: 'address' | 'geocode' | 'cities' | 'establishment' | 'geocode|establishment';
   components?: string;
 }
 


### PR DESCRIPTION
The default query type is address, while the default API type is 'geocode|establishment'. The typings are preventing us from using the combined type, which returns both addresses and businesses.

I am proposing to change the typings so at least we can use this option. It would be even better if the default type was the same than the API choice.

See:
https://developers.google.com/places/web-service/autocomplete#place_types

    "The exception is that you can safely mix the `geocode` and `establishment` types, but note that this will have the same effect as specifying no types."